### PR TITLE
Weird readonly Func

### DIFF
--- a/src/PublicApiGenerator/ApiGenerator.cs
+++ b/src/PublicApiGenerator/ApiGenerator.cs
@@ -855,7 +855,14 @@ namespace PublicApiGenerator
         static CodeTypeReference ModifyCodeTypeReference(CodeTypeReference typeReference, string modifier)
         {
             using (var provider = new CSharpCodeProvider())
-                return new CodeTypeReference(modifier + " " + provider.GetTypeOutput(typeReference));
+            {
+                if (typeReference.TypeArguments.Count == 0)
+                    // provider.GetTypeOutput(typeReference) gives int, string and so on
+                    return new CodeTypeReference(modifier + " " + provider.GetTypeOutput(typeReference));
+                else
+                    // typeReference.BaseType is System.Int32 not int, System.String not string and so on
+                    return new CodeTypeReference(modifier + " " + typeReference.BaseType, typeReference.TypeArguments.Cast<CodeTypeReference>().ToArray());
+            }
         }
 
         static CodeTypeReference CreateCodeTypeReference(TypeReference type)

--- a/src/PublicApiGeneratorTests/Field_types.cs
+++ b/src/PublicApiGeneratorTests/Field_types.cs
@@ -86,6 +86,7 @@ namespace PublicApiGeneratorTests
     public class FieldWithFunc
     {
         public readonly System.Func<string, string, string, System.Collections.Generic.IEnumerable<string>, string> FuncField;
+        public readonly System.Func<string, string, string, string> FuncField2;
         public FieldWithFunc() { }
     }
 }");
@@ -124,6 +125,7 @@ namespace PublicApiGeneratorTests
         public class FieldWithFunc
         {
             public readonly Func<string, string, string, IEnumerable<string>, string> FuncField = (a, b, c, d) => null;
+            public readonly Func<string, string, string, string> FuncField2;
         }
     }
     // ReSharper restore UnusedMember.Global

--- a/src/PublicApiGeneratorTests/Field_types.cs
+++ b/src/PublicApiGeneratorTests/Field_types.cs
@@ -1,4 +1,6 @@
 ﻿using PublicApiGeneratorTests.Examples;
+using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace PublicApiGeneratorTests
@@ -74,6 +76,20 @@ namespace PublicApiGeneratorTests
     }
 }");
         }
+
+        [Fact]
+        public void Should_output_readonly_func_with_type_arguments()
+        {
+            AssertPublicApi<FieldWithFunc>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class FieldWithFunc
+    {
+        public readonly System.Func<string, string, string, System.Collections.Generic.IEnumerable<string>, string> FuncField;
+        public FieldWithFunc() { }
+    }
+}");
+        }
     }
 
     // ReSharper disable ClassNeverInstantiated.Global
@@ -103,6 +119,11 @@ namespace PublicApiGeneratorTests
         public class FieldWithMultipleGenericTypeParameters
         {
             public GenericTypeExtra<int, string, ComplexType> Field;
+        }
+
+        public class FieldWithFunc
+        {
+            public readonly Func<string, string, string, IEnumerable<string>, string> FuncField = (a, b, c, d) => null;
         }
     }
     // ReSharper restore UnusedMember.Global


### PR DESCRIPTION
Fixes issue when 
`public readonly System.Func<a,b,c,d> Some;`
 become
 `public readonly System.Func<a Some;`

@danielmarbach I stumbled upon this by accident. I localized the problem - it happens if the control falls into the `ModifyCodeTypeReference` method. If `typeReference` has any `TypeArguments` then after call to `new CodeTypeReference(modifier + " " + provider.GetTypeOutput(typeReference))` there are 0 `TypeArguments` in newly created `CodeTypeReference`. Well, then comes complete nonsense.
If you call a constructor that accepts second argument - `params CodeTypeReference[] typeArguments`, then the output changes (`int` -> `System.Int32`, `string` -> `System.String` and so on) and some tests fail.

I used a simple if condition and made all the tests work. But I **do not like it**. This is a temporary solution just to PR. I have no experience with CodeDom. I think you better know what to do in this case. Perhaps everything is simple and we should switch to a new constructor without a condition. Please see how to fix it.
