### PR TITLE
Fix visibility issues with events, nested types, and 'private protected'

### DIFF
--- a/src/PublicApiGenerator/ApiGenerator.cs
+++ b/src/PublicApiGenerator/ApiGenerator.cs
@@ -99,7 +99,7 @@ namespace PublicApiGenerator
 
         static bool ShouldIncludeType(TypeDefinition t)
         {
-            return (t.IsPublic || t.IsNestedPublic || t.IsNestedFamily) && !t.IsCompilerGenerated();
+            return (t.IsPublic || t.IsNestedPublic || t.IsNestedFamily || t.IsNestedFamilyOrAssembly) && !t.IsCompilerGenerated();
         }
 
         static bool ShouldIncludeMember(IMemberDefinition m, string[] whitelistedNamespacePrefixes)
@@ -153,7 +153,7 @@ namespace PublicApiGenerator
             TypeAttributes attributes = 0;
             if (publicType.IsPublic || publicType.IsNestedPublic)
                 attributes |= TypeAttributes.Public;
-            if (publicType.IsNestedFamily)
+            if (publicType.IsNestedFamily || publicType.IsNestedFamilyOrAssembly)
                 attributes |= TypeAttributes.NestedFamily;
             if (publicType.IsSealed && !publicType.IsAbstract)
                 attributes |= TypeAttributes.Sealed;

--- a/src/PublicApiGenerator/ApiGenerator.cs
+++ b/src/PublicApiGenerator/ApiGenerator.cs
@@ -616,7 +616,7 @@ namespace PublicApiGenerator
             if (!(hasGet | hasSet))
                 return;
 
-            var propertyAttributes = CecilEx.GetPropertyAttributes(getterAttributes, setterAttributes);
+            var propertyAttributes = CecilEx.CombineAccessorAttributes(getterAttributes, setterAttributes);
 
             var propertyType = member.PropertyType.IsGenericParameter
                 ? new CodeTypeReference(member.PropertyType.Name)
@@ -667,7 +667,7 @@ namespace PublicApiGenerator
             var @event = new CodeMemberEvent
             {
                 Name = eventDefinition.Name,
-                Attributes = MemberAttributes.Public | MemberAttributes.Final,
+                Attributes = CecilEx.CombineAccessorAttributes(addAccessorAttributes, removeAccessorAttributes),
                 CustomAttributes = CreateCustomAttributes(eventDefinition, attributeFilter),
                 Type = eventDefinition.EventType.CreateCodeTypeReference(eventDefinition)
             };

--- a/src/PublicApiGenerator/ApiGenerator.cs
+++ b/src/PublicApiGenerator/ApiGenerator.cs
@@ -148,7 +148,7 @@ namespace PublicApiGenerator
                 }
                 else if (memberInfo is EventDefinition eventDefinition)
                 {
-                    typeDeclaration.Members.Add(GenerateEvent(eventDefinition, attributeFilter));
+                    AddEventToTypeDeclaration(typeDeclaration, eventDefinition, attributeFilter);
                 }
                 else if (memberInfo is FieldDefinition fieldDefinition)
                 {
@@ -653,8 +653,11 @@ namespace PublicApiGenerator
             typeDeclaration.Members.Add(property);
         }
 
-        static CodeTypeMember GenerateEvent(EventDefinition eventDefinition, AttributeFilter attributeFilter)
+        static void AddEventToTypeDeclaration(CodeTypeDeclaration typeDeclaration, EventDefinition eventDefinition, AttributeFilter attributeFilter)
         {
+            if (!(ShouldIncludeMethod(eventDefinition.AddMethod.Attributes) || ShouldIncludeMethod(eventDefinition.RemoveMethod.Attributes)))
+                return;
+
             var @event = new CodeMemberEvent
             {
                 Name = eventDefinition.Name,
@@ -663,7 +666,7 @@ namespace PublicApiGenerator
                 Type = eventDefinition.EventType.CreateCodeTypeReference(eventDefinition)
             };
 
-            return @event;
+            typeDeclaration.Members.Add(@event);
         }
 
         static void AddFieldToTypeDeclaration(CodeTypeDeclaration typeDeclaration, FieldDefinition memberInfo, AttributeFilter attributeFilter)

--- a/src/PublicApiGenerator/CecilEx.cs
+++ b/src/PublicApiGenerator/CecilEx.cs
@@ -58,33 +58,33 @@ namespace PublicApiGenerator
             return m.CustomAttributes.Any(a => a.AttributeType.FullName == "System.Runtime.CompilerServices.CompilerGeneratedAttribute");
         }
 
-        public static MemberAttributes GetPropertyAttributes(MemberAttributes getterAttributes, MemberAttributes setterAttributes)
+        public static MemberAttributes CombineAccessorAttributes(MemberAttributes first, MemberAttributes second)
         {
             MemberAttributes access = 0;
-            var getterAccess = getterAttributes & MemberAttributes.AccessMask;
-            var setterAccess = setterAttributes & MemberAttributes.AccessMask;
-            if (getterAccess == MemberAttributes.Public || setterAccess == MemberAttributes.Public)
+            var firstAccess = first & MemberAttributes.AccessMask;
+            var secondAccess = second & MemberAttributes.AccessMask;
+            if (firstAccess == MemberAttributes.Public || secondAccess == MemberAttributes.Public)
                 access = MemberAttributes.Public;
-            else if (getterAccess == MemberAttributes.Family || setterAccess == MemberAttributes.Family)
+            else if (firstAccess == MemberAttributes.Family || secondAccess == MemberAttributes.Family)
                 access = MemberAttributes.Family;
-            else if (getterAccess == MemberAttributes.FamilyAndAssembly || setterAccess == MemberAttributes.FamilyAndAssembly)
+            else if (firstAccess == MemberAttributes.FamilyAndAssembly || secondAccess == MemberAttributes.FamilyAndAssembly)
                 access = MemberAttributes.FamilyAndAssembly;
-            else if (getterAccess == MemberAttributes.FamilyOrAssembly || setterAccess == MemberAttributes.FamilyOrAssembly)
+            else if (firstAccess == MemberAttributes.FamilyOrAssembly || secondAccess == MemberAttributes.FamilyOrAssembly)
                 access = MemberAttributes.FamilyOrAssembly;
-            else if (getterAccess == MemberAttributes.Assembly || setterAccess == MemberAttributes.Assembly)
+            else if (firstAccess == MemberAttributes.Assembly || secondAccess == MemberAttributes.Assembly)
                 access = MemberAttributes.Assembly;
-            else if (getterAccess == MemberAttributes.Private || setterAccess == MemberAttributes.Private)
+            else if (firstAccess == MemberAttributes.Private || secondAccess == MemberAttributes.Private)
                 access = MemberAttributes.Private;
 
             // Scope should be the same for getter and setter. If one isn't specified, it'll be 0
-            var getterScope = getterAttributes & MemberAttributes.ScopeMask;
-            var setterScope = setterAttributes & MemberAttributes.ScopeMask;
-            var scope = (MemberAttributes)Math.Max((int)getterScope, (int)setterScope);
+            var firstScope = first & MemberAttributes.ScopeMask;
+            var secondScope = second & MemberAttributes.ScopeMask;
+            var scope = (MemberAttributes)Math.Max((int)firstScope, (int)secondScope);
 
             // Vtable should be the same for getter and setter. If one isn't specified, it'll be 0
-            var getterVtable = getterAttributes & MemberAttributes.VTableMask;
-            var setterVtable = setterAttributes & MemberAttributes.VTableMask;
-            var vtable = (MemberAttributes)Math.Max((int)getterVtable, (int)setterVtable);
+            var firstVtable = first & MemberAttributes.VTableMask;
+            var secondVtable = second & MemberAttributes.VTableMask;
+            var vtable = (MemberAttributes)Math.Max((int)firstVtable, (int)secondVtable);
 
             return access | scope | vtable;
         }

--- a/src/PublicApiGenerator/CecilEx.cs
+++ b/src/PublicApiGenerator/CecilEx.cs
@@ -58,14 +58,6 @@ namespace PublicApiGenerator
             return m.CustomAttributes.Any(a => a.AttributeType.FullName == "System.Runtime.CompilerServices.CompilerGeneratedAttribute");
         }
 
-        public static bool HasVisiblePropertyMethod(this MemberAttributes attributes)
-        {
-            var access = attributes & MemberAttributes.AccessMask;
-            return access == MemberAttributes.Public ||
-                   access == MemberAttributes.Family ||
-                   access == MemberAttributes.FamilyOrAssembly;
-        }
-
         public static MemberAttributes GetPropertyAttributes(MemberAttributes getterAttributes, MemberAttributes setterAttributes)
         {
             MemberAttributes access = 0;

--- a/src/PublicApiGeneratorTests/Class_constructors.cs
+++ b/src/PublicApiGeneratorTests/Class_constructors.cs
@@ -40,6 +40,16 @@ namespace PublicApiGeneratorTests
         }
 
         [Fact]
+        public void Should_not_output_private_protected_constructor()
+        {
+            AssertPublicApi<ClassWithPrivateProtectedConstructor>(
+                @"namespace PublicApiGeneratorTests.Examples
+{
+    public class ClassWithPrivateProtectedConstructor { }
+}");
+        }
+
+        [Fact]
         public void Should_output_public_constructor()
         {
             AssertPublicApi<ClassWithPublicConstructor>(
@@ -56,11 +66,24 @@ namespace PublicApiGeneratorTests
         public void Should_output_protected_constructor()
         {
             AssertPublicApi<ClassWithProtectedConstructor>(
-@"namespace PublicApiGeneratorTests.Examples
+                @"namespace PublicApiGeneratorTests.Examples
 {
     public class ClassWithProtectedConstructor
     {
         protected ClassWithProtectedConstructor() { }
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_output_protected_internal_constructor()
+        {
+            AssertPublicApi<ClassWithProtectedInternalConstructor>(
+                @"namespace PublicApiGeneratorTests.Examples
+{
+    public class ClassWithProtectedInternalConstructor
+    {
+        protected ClassWithProtectedInternalConstructor() { }
     }
 }");
         }
@@ -130,9 +153,23 @@ namespace PublicApiGeneratorTests
             }
         }
 
+        public class ClassWithPrivateProtectedConstructor
+        {
+            private protected ClassWithPrivateProtectedConstructor()
+            {
+            }
+        }
+
         public class ClassWithProtectedConstructor
         {
             protected ClassWithProtectedConstructor()
+            {
+            }
+        }
+
+        public class ClassWithProtectedInternalConstructor
+        {
+            protected internal ClassWithProtectedInternalConstructor()
             {
             }
         }

--- a/src/PublicApiGeneratorTests/Class_nested.cs
+++ b/src/PublicApiGeneratorTests/Class_nested.cs
@@ -40,6 +40,34 @@ namespace PublicApiGeneratorTests
         }
 
         [Fact]
+        public void Should_ignore_internal_nested_class()
+        {
+            AssertPublicApi<ClassWithInternalNestedClass>(
+                @"namespace PublicApiGeneratorTests.Examples
+{
+    public class ClassWithInternalNestedClass
+    {
+        public ClassWithInternalNestedClass() { }
+        public void Method() { }
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_ignore_private_protected_nested_class()
+        {
+            AssertPublicApi<ClassWithPrivateProtectedNestedClass>(
+                @"namespace PublicApiGeneratorTests.Examples
+{
+    public class ClassWithPrivateProtectedNestedClass
+    {
+        public ClassWithPrivateProtectedNestedClass() { }
+        public void Method() { }
+    }
+}");
+        }
+
+        [Fact]
         public void Should_output_protected_nested_class()
         {
             AssertPublicApi<ClassWithProtectedNestedClass>(
@@ -48,6 +76,25 @@ namespace PublicApiGeneratorTests
     public class ClassWithProtectedNestedClass
     {
         public ClassWithProtectedNestedClass() { }
+        public void Method() { }
+        protected class NestedClass
+        {
+            public NestedClass() { }
+            public void Method() { }
+        }
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_output_protected_internal_nested_class()
+        {
+            AssertPublicApi<ClassWithProtectedInternalNestedClass>(
+                @"namespace PublicApiGeneratorTests.Examples
+{
+    public class ClassWithProtectedInternalNestedClass
+    {
+        public ClassWithProtectedInternalNestedClass() { }
         public void Method() { }
         protected class NestedClass
         {
@@ -217,9 +264,39 @@ namespace PublicApiGeneratorTests
             public void Method() { }
         }
 
+        public class ClassWithInternalNestedClass
+        {
+            internal class NestedClass
+            {
+                public void Method() { }
+            }
+
+            public void Method() { }
+        }
+
         public class ClassWithProtectedNestedClass
         {
             protected class NestedClass
+            {
+                public void Method() { }
+            }
+
+            public void Method() { }
+        }
+
+        public class ClassWithProtectedInternalNestedClass
+        {
+            protected internal class NestedClass
+            {
+                public void Method() { }
+            }
+
+            public void Method() { }
+        }
+
+        public class ClassWithPrivateProtectedNestedClass
+        {
+            private protected class NestedClass
             {
                 public void Method() { }
             }

--- a/src/PublicApiGeneratorTests/Event_visibility.cs
+++ b/src/PublicApiGeneratorTests/Event_visibility.cs
@@ -1,0 +1,130 @@
+﻿using PublicApiGeneratorTests.Examples;
+using System;
+using Xunit;
+
+namespace PublicApiGeneratorTests
+{
+    public class Event_visibility :  ApiGeneratorTestsBase
+    {
+        [Fact]
+        public void Should_output_public_event()
+        {
+            AssertPublicApi<ClassWithPublicEvent>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class ClassWithPublicEvent
+    {
+        public ClassWithPublicEvent() { }
+        public event System.EventHandler Event;
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_output_protected_event()
+        {
+            AssertPublicApi<ClassWithProtectedEvent>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class ClassWithProtectedEvent
+    {
+        public ClassWithProtectedEvent() { }
+        protected event System.EventHandler Event;
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_output_protected_internal_event()
+        {
+            AssertPublicApi<ClassWithProtectedInternalEvent>(
+                @"namespace PublicApiGeneratorTests.Examples
+{
+    public class ClassWithProtectedInternalEvent
+    {
+        public ClassWithProtectedInternalEvent() { }
+        protected event System.EventHandler Event;
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_not_output_private_protected_event()
+        {
+            AssertPublicApi<ClassWithPrivateProtectedEvent>(
+                @"namespace PublicApiGeneratorTests.Examples
+{
+    public class ClassWithPrivateProtectedEvent
+    {
+        public ClassWithPrivateProtectedEvent() { }
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_not_output_private_event()
+        {
+            AssertPublicApi<ClassWithPrivateEvent>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class ClassWithPrivateEvent
+    {
+        public ClassWithPrivateEvent() { }
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_not_output_internal_event()
+        {
+            AssertPublicApi<ClassWithInternalEvent>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class ClassWithInternalEvent
+    {
+        public ClassWithInternalEvent() { }
+    }
+}");
+        }
+    }
+
+    // ReSharper disable ClassNeverInstantiated.Global
+    // ReSharper disable UnusedMember.Global
+    // ReSharper disable UnusedMember.Local
+    // ReSharper disable UnusedAutoEventAccessor.Local
+    namespace Examples
+    {
+        public class ClassWithPublicEvent
+        {
+            public event EventHandler Event;
+        }
+
+        public class ClassWithProtectedEvent
+        {
+            protected event EventHandler Event;
+        }
+
+        public class ClassWithPrivateEvent
+        {
+            private event EventHandler Event;
+        }
+
+        public class ClassWithInternalEvent
+        {
+            internal event EventHandler Event;
+        }
+
+        public class ClassWithProtectedInternalEvent
+        {
+            protected internal event EventHandler Event;
+        }
+
+        public class ClassWithPrivateProtectedEvent
+        {
+            private protected event EventHandler Event;
+        }
+    }
+    // ReSharper restore UnusedMember.Local
+    // ReSharper restore UnusedMember.Global
+    // ReSharper restore ClassNeverInstantiated.Global
+}

--- a/src/PublicApiGeneratorTests/Field_visibility.cs
+++ b/src/PublicApiGeneratorTests/Field_visibility.cs
@@ -34,6 +34,7 @@ namespace PublicApiGeneratorTests
         {
             private int privateFieldNotVisible;
             internal int internalFieldNotVisible;
+            private protected int privateProtectedFieldNotVisible;
 
             protected int protectedFieldIsVisible;
             protected internal int protectedInternalFieldIsVisible;

--- a/src/PublicApiGeneratorTests/Keyword_order.cs
+++ b/src/PublicApiGeneratorTests/Keyword_order.cs
@@ -1,0 +1,64 @@
+﻿using PublicApiGeneratorTests.Examples;
+using Xunit;
+
+namespace PublicApiGeneratorTests
+{
+    public class Keyword_order : ApiGeneratorTestsBase
+    {
+        [Fact]
+        public void Include_static_fields()
+        {
+            AssertPublicApi<ClassWithStaticFields>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class ClassWithStaticFields
+    {
+        protected static string StaticProtectedField;
+        public static int StaticPublicField;
+        public ClassWithStaticFields() { }
+    }
+}");
+        }
+
+        [Fact]
+        public void Include_readonly_fields_without_constant_values()
+        {
+            // TODO: Initializing values are set in the constructor. Very tricky to get
+            AssertPublicApi<ClassWithReadonlyFields>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class ClassWithReadonlyFields
+    {
+        protected readonly string ReadonlyProtectedField;
+        public readonly int ReadonlyPublicField;
+        public ClassWithReadonlyFields() { }
+    }
+}");
+        }
+
+        [Fact]
+        public void Include_const_fields()
+        {
+            // Have to include the ctor - I can't figure out how to hide it
+            // when values are initialized
+            AssertPublicApi<ClassWithConstFields>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class ClassWithConstFields
+    {
+        protected const string ConstProtectedField = ""hello world"";
+        public const int ConstPublicField = 42;
+        public ClassWithConstFields() { }
+    }
+}");
+        }
+    }
+
+    // ReSharper disable ClassNeverInstantiated.Global
+    // ReSharper disable UnusedMember.Global
+    namespace Examples
+    {
+    }
+    // ReSharper restore UnusedMember.Global
+    // ReSharper restore ClassNeverInstantiated.Global
+}

--- a/src/PublicApiGeneratorTests/Method_visibility.cs
+++ b/src/PublicApiGeneratorTests/Method_visibility.cs
@@ -61,6 +61,19 @@ namespace PublicApiGeneratorTests
         }
 
         [Fact]
+        public void Should_not_show_private_protected_methods()
+        {
+            AssertPublicApi<ClassWithPrivateProtectedMethod>(
+                @"namespace PublicApiGeneratorTests.Examples
+{
+    public class ClassWithPrivateProtectedMethod
+    {
+        public ClassWithPrivateProtectedMethod() { }
+    }
+}");
+        }
+
+        [Fact]
         public void Should_not_show_private_methods()
         {
             AssertPublicApi<ClassWithPrivateMethod>(
@@ -103,6 +116,13 @@ namespace PublicApiGeneratorTests
         public class ClassWithProtectedInternalMethod
         {
             protected internal void DoSomething()
+            {
+            }
+        }
+
+        public class ClassWithPrivateProtectedMethod
+        {
+            private protected void DoSomething()
             {
             }
         }

--- a/src/PublicApiGeneratorTests/Property_visibility.cs
+++ b/src/PublicApiGeneratorTests/Property_visibility.cs
@@ -37,12 +37,25 @@ namespace PublicApiGeneratorTests
         public void Should_output_protected_internal_property()
         {
             AssertPublicApi<ClassWithProtectedInternalProperty>(
-@"namespace PublicApiGeneratorTests.Examples
+                @"namespace PublicApiGeneratorTests.Examples
 {
     public class ClassWithProtectedInternalProperty
     {
         public ClassWithProtectedInternalProperty() { }
         protected string Value { get; set; }
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_not_output_private_protected_property()
+        {
+            AssertPublicApi<ClassWithPrivateProtectedProperty>(
+                @"namespace PublicApiGeneratorTests.Examples
+{
+    public class ClassWithPrivateProtectedProperty
+    {
+        public ClassWithPrivateProtectedProperty() { }
     }
 }");
         }
@@ -134,12 +147,26 @@ namespace PublicApiGeneratorTests
         public void Should_output_protected_internal_setter_for_public_property()
         {
             AssertPublicApi<ClassWithPublicGetterProtectedInternalSetter>(
-@"namespace PublicApiGeneratorTests.Examples
+                @"namespace PublicApiGeneratorTests.Examples
 {
     public class ClassWithPublicGetterProtectedInternalSetter
     {
         public ClassWithPublicGetterProtectedInternalSetter() { }
         public string Value1 { get; set; }
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_not_output_private_protected_setter_for_public_property()
+        {
+            AssertPublicApi<ClassWithPublicGetterPrivateProtectedSetter>(
+                @"namespace PublicApiGeneratorTests.Examples
+{
+    public class ClassWithPublicGetterPrivateProtectedSetter
+    {
+        public ClassWithPublicGetterPrivateProtectedSetter() { }
+        public string Value1 { get; }
     }
 }");
         }
@@ -281,6 +308,11 @@ namespace PublicApiGeneratorTests
             protected internal string Value { get; set; }
         }
 
+        public class ClassWithPrivateProtectedProperty
+        {
+            private protected string Value { get; set; }
+        }
+
         public class ClassWithPublicGetterPrivateSetter
         {
             public string Value1 { get; private set; }
@@ -299,6 +331,11 @@ namespace PublicApiGeneratorTests
         public class ClassWithPublicGetterProtectedInternalSetter
         {
             public string Value1 { get; protected internal set; }
+        }
+
+        public class ClassWithPublicGetterPrivateProtectedSetter
+        {
+            public string Value1 { get; private protected set; }
         }
 
         public class ClassWithPrivateGetterPublicSetter


### PR DESCRIPTION
Fixes #109. 

I set out to fix `famandassem` members which should not be shown. They have been able to be created in .NET assemblies since the beginning.

While writing tests, I discovered that tests were missing for the visibility of events and nested `protected internal` types. I added them and they failed, so this PR fixes two additional issues:

- Events were being included and shown as `public` regardless of visibility, including private ones.
- Nested `protected internal` types were excluded even though they appear as `protected` types from outside the assembly.