### PR TITLE
Add tests showing that 'sealed override' members and event scope modifiers are not supported by CodeDOM

### DIFF
--- a/src/PublicApiGeneratorTests/Event_modifiers.cs
+++ b/src/PublicApiGeneratorTests/Event_modifiers.cs
@@ -1,0 +1,138 @@
+﻿using PublicApiGeneratorTests.Examples;
+using System;
+using Xunit;
+
+namespace PublicApiGeneratorTests
+{
+    public class Event_modifiers : ApiGeneratorTestsBase
+    {
+        [Fact(Skip = "Not supported by CodeDOM")]
+        [Trait("TODO", "Scope modifiers on events not supported by CodeDOM")]
+        public void Should_output_abstract_modifier()
+        {
+            AssertPublicApi<ClassWithAbstractEvent>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public abstract class ClassWithAbstractEvent
+    {
+        protected ClassWithAbstractEvent() { }
+        public abstract event System.EventHandler Event;
+    }
+}");
+        }
+
+        [Fact(Skip = "Not supported by CodeDOM")]
+        [Trait("TODO", "Scope modifiers on events not supported by CodeDOM")]
+        public void Should_output_static_modifier()
+        {
+            AssertPublicApi<ClassWithStaticEvent>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class ClassWithStaticEvent
+    {
+        public ClassWithStaticEvent() { }
+        public static event System.EventHandler Event;
+    }
+}");
+        }
+
+        [Fact(Skip = "Not supported by CodeDOM")]
+        [Trait("TODO", "Scope modifiers on events not supported by CodeDOM")]
+        public void Should_output_virtual_modifier()
+        {
+            AssertPublicApi<ClassWithVirtualEvent>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class ClassWithVirtualEvent
+    {
+        public ClassWithVirtualEvent() { }
+        public virtual event System.EventHandler Event;
+    }
+}");
+        }
+
+        [Fact(Skip = "Not supported by CodeDOM")]
+        [Trait("TODO", "Scope modifiers on events not supported by CodeDOM")]
+        public void Should_output_override_modifier()
+        {
+            AssertPublicApi<ClassWithOverridingEvent>(
+                @"namespace PublicApiGeneratorTests.Examples
+{
+    public class ClassWithOverridingEvent : PublicApiGeneratorTests.Examples.ClassWithVirtualEvent
+    {
+        public ClassWithOverridingEvent() { }
+        public override event System.EventHandler Event;
+    }
+}");
+        }
+
+        [Fact(Skip = "Not supported by CodeDOM")]
+        [Trait("TODO", "Scope modifiers on events not supported by CodeDOM")]
+        public void Should_output_sealed_modifier()
+        {
+            AssertPublicApi<ClassWithSealedOverridingEvent>(
+                @"namespace PublicApiGeneratorTests.Examples
+{
+    public class ClassWithSealedOverridingEvent : PublicApiGeneratorTests.Examples.ClassWithVirtualEvent
+    {
+        public ClassWithSealedOverridingEvent() { }
+        public sealed override event System.EventHandler Event;
+    }
+}");
+        }
+
+        [Fact(Skip = "Not supported by CodeDOM")]
+        [Trait("TODO", "Scope modifiers on events not supported by CodeDOM")]
+        public void Should_output_new_modifier()
+        {
+            AssertPublicApi<ClassWithEventHiding>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class ClassWithEventHiding : PublicApiGeneratorTests.Examples.ClassWithEvent
+    {
+        public ClassWithEventHiding() { }
+        public new event System.EventHandler Event;
+    }
+}");
+        }
+    }
+
+    // ReSharper disable UnusedMember.Global
+    // ReSharper disable ClassNeverInstantiated.Global
+    // ReSharper disable ValueParameterNotUsed
+    namespace Examples
+    {
+        public abstract class ClassWithAbstractEvent
+        {
+            public abstract event EventHandler Event;
+        }
+
+        public class ClassWithStaticEvent
+        {
+            public static event EventHandler Event;
+        }
+
+        public class ClassWithVirtualEvent
+        {
+            public virtual event EventHandler Event;
+        }
+
+        public class ClassWithOverridingEvent : ClassWithVirtualEvent
+        {
+            public override event EventHandler Event;
+        }
+
+        public class ClassWithSealedOverridingEvent : ClassWithVirtualEvent
+        {
+            public sealed override event EventHandler Event;
+        }
+
+        public class ClassWithEventHiding : ClassWithVirtualEvent
+        {
+            public new event EventHandler Event;
+        }
+    }
+    // ReSharper restore ValueParameterNotUsed
+    // ReSharper restore ClassNeverInstantiated.Global
+    // ReSharper restore UnusedMember.Global
+}

--- a/src/PublicApiGeneratorTests/Method_modifiers.cs
+++ b/src/PublicApiGeneratorTests/Method_modifiers.cs
@@ -50,13 +50,28 @@ namespace PublicApiGeneratorTests
         [Fact]
         public void Should_output_override_modifier()
         {
-         AssertPublicApi<ClassWithOverridingMethod>(
-@"namespace PublicApiGeneratorTests.Examples
+            AssertPublicApi<ClassWithOverridingMethod>(
+                @"namespace PublicApiGeneratorTests.Examples
 {
     public class ClassWithOverridingMethod : PublicApiGeneratorTests.Examples.ClassWithVirtualMethod
     {
         public ClassWithOverridingMethod() { }
         public override void DoSomething() { }
+    }
+}");
+        }
+
+        [Fact(Skip = "Not supported by CodeDOM")]
+        [Trait("TODO", "Sealed override members not supported by CodeDOM")]
+        public void Should_output_sealed_modifier()
+        {
+            AssertPublicApi<ClassWithSealedOverridingMethod>(
+                @"namespace PublicApiGeneratorTests.Examples
+{
+    public class ClassWithSealedOverridingMethod : PublicApiGeneratorTests.Examples.ClassWithVirtualMethod
+    {
+        public ClassWithSealedOverridingMethod() { }
+        public sealed override void DoSomething() { }
     }
 }");
         }
@@ -134,6 +149,14 @@ namespace PublicApiGeneratorTests
         public class ClassWithOverridingMethod : ClassWithVirtualMethod
         {
             public override void DoSomething()
+            {
+                base.DoSomething();
+            }
+        }
+
+        public class ClassWithSealedOverridingMethod : ClassWithVirtualMethod
+        {
+            public sealed override void DoSomething()
             {
                 base.DoSomething();
             }

--- a/src/PublicApiGeneratorTests/Property_modifiers.cs
+++ b/src/PublicApiGeneratorTests/Property_modifiers.cs
@@ -50,13 +50,28 @@ namespace PublicApiGeneratorTests
         [Fact]
         public void Should_output_override_modifier()
         {
-            AssertPublicApi<ClassWithOverriddenProperty>(
-@"namespace PublicApiGeneratorTests.Examples
+            AssertPublicApi<ClassWithOverridingProperty>(
+                @"namespace PublicApiGeneratorTests.Examples
 {
-    public class ClassWithOverriddenProperty : PublicApiGeneratorTests.Examples.ClassWithVirtualProperty
+    public class ClassWithOverridingProperty : PublicApiGeneratorTests.Examples.ClassWithVirtualProperty
     {
-        public ClassWithOverriddenProperty() { }
+        public ClassWithOverridingProperty() { }
         public override string Value { get; set; }
+    }
+}");
+        }
+
+        [Fact(Skip = "Not supported by CodeDOM")]
+        [Trait("TODO", "Sealed override members not supported by CodeDOM")]
+        public void Should_output_sealed_modifier()
+        {
+            AssertPublicApi<ClassWithSealedOverridingProperty>(
+                @"namespace PublicApiGeneratorTests.Examples
+{
+    public class ClassWithSealedOverridingProperty : PublicApiGeneratorTests.Examples.ClassWithVirtualProperty
+    {
+        public ClassWithSealedOverridingProperty() { }
+        public sealed override string Value { get; set; }
     }
 }");
         }
@@ -113,9 +128,18 @@ namespace PublicApiGeneratorTests
             }
         }
 
-        public class ClassWithOverriddenProperty : ClassWithVirtualProperty
+        public class ClassWithOverridingProperty : ClassWithVirtualProperty
         {
             public override string Value
+            {
+                get { return string.Empty; }
+                set { }
+            }
+        }
+
+        public class ClassWithSealedOverridingProperty : ClassWithVirtualProperty
+        {
+            public sealed override string Value
             {
                 get { return string.Empty; }
                 set { }


### PR DESCRIPTION
Even when CodeDOM is given e.g. `MemberAttributes.Static` for an event, it ignores it.

CodeDOM incorrectly shows `MemberAttributes.Final | MemberAttributes.Override` as `virtual` rather than `sealed override`.