### PR TITLE
C# 8 nullable reference type support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Editor default newlines with a newline ending every file
+[*]
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.cs]
+indent_size = 4
+indent_style = space

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ _[![Build status](https://github.com/JakeGinnivan/ApiApprover/workflows/.github/
 ## PublicApiGenerator
 
 PublicApiGenerator has no dependencies and simply creates a string the represents the public API. Any approval library can be used to approve the generated public API.
+PublicApiGenerator supports C# 8 [Nullable Reference Types](https://docs.microsoft.com/en-us/dotnet/csharp/nullable-references) from version 10.
 
 ## How do I use it
 

--- a/src/ApiApprover.sln
+++ b/src/ApiApprover.sln
@@ -9,8 +9,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PublicApiGenerator", "Publi
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{52361C5B-F247-42C5-8455-BD1DEDB5C903}"
 	ProjectSection(SolutionItems) = preProject
-		..\appveyor.yml = ..\appveyor.yml
-		..\build.ps1 = ..\build.ps1
+		..\.editorconfig = ..\.editorconfig
+		..\.gitattributes = ..\.gitattributes
+		..\.gitignore = ..\.gitignore
+		..\build.cmd = ..\build.cmd
+		..\build.sh = ..\build.sh
+		..\.github\workflows\ci.yml = ..\.github\workflows\ci.yml
 		Directory.Build.props = Directory.Build.props
 		..\LICENSE = ..\LICENSE
 		PublicApiGenerator.snk = PublicApiGenerator.snk

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,6 +7,7 @@
     <Copyright>Copyright Jake Ginnivan 2010-$([System.DateTime]::UtcNow.ToString(yyyy)). All rights reserved.</Copyright>
     <PackageTags>semanticversioning versioning api</PackageTags>
     <PackageOutputPath>..\..\nugets</PackageOutputPath>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/PublicApiGenerator.Tool/Program.cs
+++ b/src/PublicApiGenerator.Tool/Program.cs
@@ -250,7 +250,7 @@ public static class Program
         var asm = Assembly.LoadFile(fullPath);
         File.WriteAllText(outputPath, ApiGenerator.GeneratePublicApi(asm));
         var destinationFilePath = Path.Combine(outputDirectory, Path.GetFileName(outputPath));
-        if(File.Exists(destinationFilePath))
+        if (File.Exists(destinationFilePath))
         {
             File.Delete(destinationFilePath);
         }

--- a/src/PublicApiGenerator/CSharpAlias.cs
+++ b/src/PublicApiGenerator/CSharpAlias.cs
@@ -1,0 +1,42 @@
+namespace PublicApiGenerator
+{
+    internal static class CSharpAlias
+    {
+        public static string Get(string typeName)
+        {
+            switch (typeName)
+            {
+                case "System.Byte":
+                    return "byte";
+                case "System.SByte":
+                    return "sbyte";
+                case "System.Int16":
+                    return "short";
+                case "System.UInt16":
+                    return "ushort";
+                case "System.Int32":
+                    return "int";
+                case "System.UInt32":
+                    return "uint";
+                case "System.Int64":
+                    return "long";
+                case "System.UInt64":
+                    return "ulong";
+                case "System.Single":
+                    return "float";
+                case "System.Double":
+                    return "double";
+                case "System.Decimal":
+                    return "decimal";
+                case "System.Object":
+                    return "object";
+                case "System.String":
+                    return "string";
+                case "System.Boolean":
+                    return "bool";
+                default:
+                    return typeName;
+            }
+        }
+    }
+}

--- a/src/PublicApiGenerator/CodeTypeReferenceBuilder.cs
+++ b/src/PublicApiGenerator/CodeTypeReferenceBuilder.cs
@@ -1,0 +1,156 @@
+using Mono.Cecil;
+using System;
+using System.CodeDom;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PublicApiGenerator
+{
+    internal static class CodeTypeReferenceBuilder
+    {
+        private const int MAX_COUNT = 100;
+
+        internal static CodeTypeReference CreateCodeTypeReference(this TypeReference type, ICustomAttributeProvider attributeProvider = null, NullableMode mode = NullableMode.Default)
+        {
+            return CreateCodeTypeReferenceWithNullabilityMap(type, attributeProvider.GetNullabilityMap().GetEnumerator(), mode, false);
+        }
+
+        static CodeTypeReference CreateCodeTypeReferenceWithNullabilityMap(TypeReference type, IEnumerator<bool?> nullabilityMap, NullableMode mode, bool disableNested)
+        {
+            var typeName = GetTypeName(type, nullabilityMap, mode, disableNested);
+            if (type.IsValueType && type.Name == "Nullable`1" && type.Namespace == "System")
+            {
+                // unwrap System.Nullable<Type> into Type? for readability
+                var genericArgs = type is IGenericInstance instance ? instance.GenericArguments : type.HasGenericParameters ? type.GenericParameters.Cast<TypeReference>() : null;
+                return CreateCodeTypeReferenceWithNullabilityMap(genericArgs.Single(), nullabilityMap, NullableMode.Force, disableNested);
+            }
+            else
+            {
+                return new CodeTypeReference(typeName, CreateGenericArguments(type, nullabilityMap));
+            }
+        }
+
+        static CodeTypeReference[] CreateGenericArguments(TypeReference type, IEnumerator<bool?> nullabilityMap)
+        {
+            // ReSharper disable once RedundantEnumerableCastCall
+            var genericArgs = type is IGenericInstance instance ? instance.GenericArguments : type.HasGenericParameters ? type.GenericParameters.Cast<TypeReference>() : null;
+            if (genericArgs == null) return null;
+
+            var genericArguments = new List<CodeTypeReference>();
+            foreach (var argument in genericArgs)
+            {
+                genericArguments.Add(CreateCodeTypeReferenceWithNullabilityMap(argument, nullabilityMap,  NullableMode.Default, false));
+            }
+            return genericArguments.ToArray();
+        }
+
+        internal static IEnumerable<bool?> GetNullabilityMap(this ICustomAttributeProvider attributeProvider)
+        {
+            var nullableAttr = attributeProvider?.CustomAttributes.SingleOrDefault(d => d.AttributeType.FullName == "System.Runtime.CompilerServices.NullableAttribute");
+
+            if (nullableAttr == null)
+            {
+                foreach (var provider in NullableContext.Providers)
+                {
+                    nullableAttr = provider.CustomAttributes.SingleOrDefault(d => d.AttributeType.FullName == "System.Runtime.CompilerServices.NullableContextAttribute");
+                    if (nullableAttr != null)
+                        break;
+                }
+            }
+
+            if (nullableAttr == null)
+                return Enumerable.Repeat((bool?)null, MAX_COUNT);
+
+            var value = nullableAttr.ConstructorArguments[0].Value;
+            if (value is CustomAttributeArgument[] arguments)
+                return arguments.Select(a => Convert((byte)a.Value));
+
+            return Enumerable.Repeat(Convert((byte)value), MAX_COUNT);
+
+            // https://github.com/dotnet/roslyn/blob/master/docs/features/nullable-metadata.md 
+            // returns:
+            // true : explicitly nullable
+            // false: explicitly not nullable
+            // null : oblivious
+            bool? Convert(byte value)
+            {
+                switch (value)
+                {
+                    case 2: return true;
+                    case 1: return false;
+                    case 0: return null;
+                    default: throw new NotSupportedException(value.ToString());
+                }
+            }
+        }
+
+        // The compiler optimizes the size of metadata bypassing a sequence of bytes for value types.
+        // Thus, it can even delete the entire NullableAttribute if the whole signature consists only of value types,
+        // for example KeyValuePair<int, int?>, thus we can call IsNullable() only by looking first deep into the signature
+        private static bool HasAnyReferenceType(TypeReference type)
+        {
+            if (!type.IsValueType)
+                return true;
+
+            // ReSharper disable once RedundantEnumerableCastCall
+            var genericArgs = type is IGenericInstance instance ? instance.GenericArguments : type.HasGenericParameters ? type.GenericParameters.Cast<TypeReference>() : null;
+            if (genericArgs == null) return false;
+
+            foreach (var argument in genericArgs)
+            {
+                if (HasAnyReferenceType(argument))
+                    return true;
+            }
+
+            return false;
+        }
+
+        static string GetTypeName(TypeReference type, IEnumerator<bool?> nullabilityMap, NullableMode mode, bool disableNested)
+        {
+            bool nullable = mode != NullableMode.Disable && (mode == NullableMode.Force || HasAnyReferenceType(type) && IsNullable());
+
+            var typeName = GetTypeNameCore(type, nullabilityMap, nullable, disableNested);
+
+            if (nullable && typeName != "System.Void")
+                typeName = CSharpAlias.Get(typeName) + "?";
+
+            return typeName;
+
+            bool IsNullable()
+            {
+                if (nullabilityMap == null)
+                    return false;
+
+                if (!nullabilityMap.MoveNext())
+                {
+                    throw new InvalidOperationException("Not enough nullability information");
+                }
+                return nullabilityMap.Current == true;
+            }
+        }
+
+        static string GetTypeNameCore(TypeReference type, IEnumerator<bool?> nullabilityMap, bool nullable, bool disableNested)
+        {
+            if (type.IsGenericParameter)
+            {
+                return type.Name;
+            }
+
+            if (type is ArrayType array)
+            {
+                if (nullable)
+                    return CSharpAlias.Get(GetTypeName(array.ElementType, nullabilityMap, NullableMode.Default, disableNested)) + "[]";
+                else
+                    return GetTypeName(array.ElementType, nullabilityMap, NullableMode.Default, disableNested) + "[]";
+            }
+
+            if (!type.IsNested || disableNested)
+            {
+                var name = type is RequiredModifierType modType ? modType.ElementType.Name : type.Name;
+                return (!string.IsNullOrEmpty(type.Namespace) ? (type.Namespace + ".") : "") + name;
+            }
+
+            return GetTypeName(type.DeclaringType, null, NullableMode.Default, false) + "." + GetTypeName(type, null, NullableMode.Default, true);
+        }
+    }
+}

--- a/src/PublicApiGenerator/NullableContext.cs
+++ b/src/PublicApiGenerator/NullableContext.cs
@@ -1,0 +1,40 @@
+﻿using Mono.Cecil;
+using System;
+using System.Collections.Generic;
+
+namespace PublicApiGenerator
+{
+    // https://github.com/dotnet/roslyn/blob/master/docs/features/nullable-metadata.md#nullablecontextattribute
+    internal class NullableContext
+    {
+        [ThreadStatic]
+        private static Stack<ICustomAttributeProvider> _nullableContextProviders;
+
+        private static Stack<ICustomAttributeProvider> NullableContextProviders
+        {
+            get
+            {
+                if (_nullableContextProviders == null)
+                    _nullableContextProviders = new Stack<ICustomAttributeProvider>();
+                return _nullableContextProviders;
+            }
+        }
+
+        internal static IDisposable Push(ICustomAttributeProvider provider) => new PopDisposable(provider);
+
+        internal static IEnumerable<ICustomAttributeProvider> Providers => NullableContextProviders;
+
+        private sealed class PopDisposable : IDisposable
+        {
+            public PopDisposable(ICustomAttributeProvider provider)
+            {
+                NullableContextProviders.Push(provider);
+            }
+
+            public void Dispose()
+            {
+                NullableContextProviders.Pop();
+            }
+        }
+    }
+}

--- a/src/PublicApiGenerator/NullableMode.cs
+++ b/src/PublicApiGenerator/NullableMode.cs
@@ -1,0 +1,9 @@
+namespace PublicApiGenerator
+{
+    enum NullableMode
+    {
+        Default,
+        Force,
+        Disable
+    }
+}

--- a/src/PublicApiGenerator/PublicApiGenerator.csproj
+++ b/src/PublicApiGenerator/PublicApiGenerator.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="MinVer" Version="1.1.0" PrivateAssets="All" />
-    <PackageReference Include="Mono.Cecil" Version="0.10.4" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.0" />
     <PackageReference Include="System.CodeDom" Version="4.5.0" />
   </ItemGroup>
 

--- a/src/PublicApiGeneratorTests/ApiGeneratorTestsBase.cs
+++ b/src/PublicApiGeneratorTests/ApiGeneratorTestsBase.cs
@@ -19,9 +19,9 @@ namespace PublicApiGeneratorTests
             AssertPublicApi(new[] { type }, expectedOutput, includeAssemblyAttributes, excludeAttributes: excludeAttributes);
         }
 
-        protected void AssertPublicApi(Type[] types, string expectedOutput, bool includeAssemblyAttributes = false, string[] whitelistedNamespacePrefixes = default(string[]), string[] excludeAttributes = null)
+        protected void AssertPublicApi(Type[] types, string expectedOutput, bool includeAssemblyAttributes = false, string[] whitelistedNamespacePrefixes = default, string[] excludeAttributes = null)
         {
-            AssertPublicApi(GetType().Assembly, types, expectedOutput, includeAssemblyAttributes, whitelistedNamespacePrefixes, excludeAttributes);
+            AssertPublicApi(types[0].Assembly, types, expectedOutput, includeAssemblyAttributes, whitelistedNamespacePrefixes, excludeAttributes);
         }
 
         private static void AssertPublicApi(Assembly assembly, Type[] types, string expectedOutput, bool includeAssemblyAttributes, string[] whitelistedNamespacePrefixes, string[] excludeAttributes)

--- a/src/PublicApiGeneratorTests/Class_nested.cs
+++ b/src/PublicApiGeneratorTests/Class_nested.cs
@@ -1,4 +1,5 @@
-﻿using PublicApiGeneratorTests.Examples;
+using PublicApiGeneratorTests.Examples;
+using System.Collections.Generic;
 using Xunit;
 
 namespace PublicApiGeneratorTests
@@ -124,6 +125,71 @@ namespace PublicApiGeneratorTests
     }
 }");
         }
+
+        [Fact]
+        public void Should_output_Nested_Classes_From_NullableExample1()
+        {
+            AssertPublicApi(typeof(Foo),
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class Foo
+    {
+        public Foo(PublicApiGeneratorTests.Examples.Foo.Bar bar) { }
+        public class Bar
+        {
+            public Bar(PublicApiGeneratorTests.Examples.Foo.Bar.Baz? baz) { }
+            public class Baz
+            {
+                public Baz() { }
+            }
+        }
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_output_Nested_Classes_From_NullableExample2()
+        {
+            AssertPublicApi(typeof(Foo<>),
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class Foo<T>
+    {
+        public Foo(PublicApiGeneratorTests.Examples.Foo<T>.Bar<int> bar) { }
+        public class Bar<U>
+        {
+            public Bar(PublicApiGeneratorTests.Examples.Foo<T>.Bar<U>.Baz<T, U>? baz) { }
+            public class Baz<V, K>
+            {
+                public Baz() { }
+            }
+        }
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_Not_Output_Generic_Parameters_From_Declaring_Type()
+        {
+            AssertPublicApi(typeof(Foo<,>),
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class Foo<T1, T2>
+    {
+        public Foo() { }
+        public class Bar
+        {
+            public T1 Data;
+            public Bar() { }
+        }
+        public class Bar<T3>
+        {
+            public System.Collections.Generic.List<T2>? Field;
+            public Bar() { }
+        }
+    }
+}");
+        }
     }
 
     // ReSharper disable UnusedMember.Global
@@ -204,6 +270,52 @@ namespace PublicApiGeneratorTests
             }
 
             public void Method() { }
+        }
+
+#nullable enable
+
+        // nullable example
+        public class Foo
+        {
+            public class Bar
+            {
+                public class Baz { }
+
+                public Bar(Baz? baz) { }
+            }
+
+            public Foo(Bar bar)
+            {
+            }
+        }
+
+        // nullable generic example 1
+        public class Foo<T>
+        {
+            public class Bar<U>
+            {
+                public class Baz<V, K> { }
+
+                public Bar(Baz<T, U>? baz) { }
+            }
+
+            public Foo(Bar<int> bar)
+            {
+            }
+        }
+
+        // nullable generic example 2
+        public class Foo<T1, T2>
+        {
+            public class Bar
+            {
+                public T1 Data;
+            }
+
+            public class Bar<T3>
+            {
+                public List<T2>? Field;
+            }
         }
     }
     // ReSharper restore UnusedMember.Local

--- a/src/PublicApiGeneratorTests/Dynamics.cs
+++ b/src/PublicApiGeneratorTests/Dynamics.cs
@@ -1,0 +1,44 @@
+using PublicApiGeneratorTests.Examples;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace PublicApiGeneratorTests
+{
+    public class Dynamics : ApiGeneratorTestsBase
+    {
+        [Fact(Skip = "Needs investigation")]
+        public void Should_output_dynamic()
+        {
+            AssertPublicApi<ClassWithDynamic>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class ClassWithDynamic : System.Collections.Generic.List<dynamic>
+    {
+        public class ClassWithDynamic2 : System.Collections.Generic.List<dynamic?> { }
+        public ClassWithDynamic() { }
+        public dynamic DoIt1(dynamic p) { }
+        public dynamic? DoIt2(dynamic? p) { }
+    }
+}");
+        }
+
+        // TODO: Enum with flags + undefined value
+        // Not supported by Cecil?
+    }
+
+    // ReSharper disable UnusedMember.Global
+    namespace Examples
+    {
+#nullable enable
+        public class ClassWithDynamic : List<dynamic>
+        {
+            public class ClassWithDynamic2 : List<dynamic?> { }
+
+            public dynamic DoIt1(dynamic p) { throw null; }
+
+            public dynamic? DoIt2(dynamic? p) { throw null; }
+        }
+    }
+    // ReSharper restore UnusedMember.Global
+}

--- a/src/PublicApiGeneratorTests/Field_modifiers.cs
+++ b/src/PublicApiGeneratorTests/Field_modifiers.cs
@@ -1,4 +1,4 @@
-﻿using PublicApiGeneratorTests.Examples;
+using PublicApiGeneratorTests.Examples;
 using Xunit;
 
 namespace PublicApiGeneratorTests
@@ -16,6 +16,20 @@ namespace PublicApiGeneratorTests
         protected static string StaticProtectedField;
         public static int StaticPublicField;
         public ClassWithStaticFields() { }
+    }
+}");
+        }
+
+        [Fact]
+        public void Include_Volatile_field_Without_modreq()
+        {
+            AssertPublicApi<ClassWithVolatileField>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class ClassWithVolatileField
+    {
+        public static int StaticVolatilePublicField;
+        public ClassWithVolatileField() { }
     }
 }");
         }
@@ -62,6 +76,11 @@ namespace PublicApiGeneratorTests
         {
             public static int StaticPublicField;
             protected static string StaticProtectedField;
+        }
+
+        public class ClassWithVolatileField
+        {
+            public static volatile int StaticVolatilePublicField;
         }
 
         public class ClassWithReadonlyFields

--- a/src/PublicApiGeneratorTests/NullableTests.cs
+++ b/src/PublicApiGeneratorTests/NullableTests.cs
@@ -1,0 +1,650 @@
+using PublicApiGeneratorTests.Examples;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace PublicApiGeneratorTests
+{
+    // Tests for https://github.com/ApiApprover/ApiApprover/issues/54
+    // See also https://github.com/dotnet/roslyn/blob/master/docs/features/nullable-reference-types.md
+    [Trait("NRT", "Nullable Reference Types")]
+    public class NullableTests : ApiGeneratorTestsBase
+    {
+        [Fact]
+        public void Should_Annotate_ReturnType()
+        {
+            AssertPublicApi<ReturnType>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class ReturnType
+    {
+        public ReturnType() { }
+        public string? ReturnProperty { get; set; }
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_Annotate_VoidReturn()
+        {
+            AssertPublicApi(typeof(VoidReturn),
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class static VoidReturn
+    {
+        public static void ShouldBeEquivalentTo(this object? actual, object? expected) { }
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_Annotate_Derived_ReturnType()
+        {
+            AssertPublicApi<ReturnArgs>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class ReturnArgs : System.EventArgs
+    {
+        public ReturnArgs() { }
+        public string? Target { get; set; }
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_Annotate_Ctor_Args()
+        {
+            AssertPublicApi<NullableCtor>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class NullableCtor
+    {
+        public NullableCtor(string? nullableLabel, string nope) { }
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_Not_Annotate_Obsolete_Attribute()
+        {
+            AssertPublicApi<ClassWithObsolete>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    [System.ObsoleteAttribute(""Foo"")]
+    public class ClassWithObsolete
+    {
+        [System.ObsoleteAttribute(""Bar"")]
+        public ClassWithObsolete(string? nullableLabel) { }
+        [System.ObsoleteAttribute(""Bar"")]
+        public ClassWithObsolete(string? nullableLabel, string? nullableLabel2) { }
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_Annotate_Generic_Event()
+        {
+            AssertPublicApi<GenericEvent>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class GenericEvent
+    {
+           public GenericEvent() { }
+           public event System.EventHandler<PublicApiGeneratorTests.Examples.ReturnArgs?> ReturnEvent;
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_Annotate_Delegate_Declaration()
+        {
+            AssertPublicApi<DelegateDeclaration>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class DelegateDeclaration
+    {
+           public DelegateDeclaration() { }
+           public delegate string? OnNullableReturn(object sender, PublicApiGeneratorTests.Examples.ReturnArgs? args);
+           public delegate string OnReturn(object sender, PublicApiGeneratorTests.Examples.ReturnArgs? args);
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_Annotate_Nullable_Array()
+        {
+            AssertPublicApi<NullableArray>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class NullableArray
+    {
+        public NullableArray() { }
+        public PublicApiGeneratorTests.Examples.ReturnType[]? NullableMethod1() { }
+        public PublicApiGeneratorTests.Examples.ReturnType[]?[]? NullableMethod2() { }
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_Annotate_Nullable_Enumerable()
+        {
+            AssertPublicApi<NullableEnumerable>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class NullableEnumerable
+    {
+        public NullableEnumerable() { }
+        public System.Collections.Generic.IEnumerable<PublicApiGeneratorTests.Examples.ReturnType?>? Enumerable() { }
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_Annotate_Generic_Method()
+        {
+            AssertPublicApi<GenericMethod>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class GenericMethod
+    {
+        public GenericMethod() { }
+        public PublicApiGeneratorTests.Examples.ReturnType? NullableGenericMethod<T1, T2, T3>(T1? t1, T2 t2, T3? t3)
+            where T1 :  class
+            where T2 :  class
+            where T3 :  class { }
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_Annotate_Skeet_Examples()
+        {
+            AssertPublicApi<SkeetExamplesClass>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class SkeetExamplesClass
+    {
+        public System.Collections.Generic.Dictionary<System.Collections.Generic.List<string?>, string[]?> SkeetExample;
+        public System.Collections.Generic.Dictionary<System.Collections.Generic.List<string?>, string?[]> SkeetExample2;
+        public System.Collections.Generic.Dictionary<System.Collections.Generic.List<string?>, string?[]?> SkeetExample3;
+        public SkeetExamplesClass() { }
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_Annotate_By_Ref()
+        {
+            AssertPublicApi<ByRefClass>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class ByRefClass
+    {
+        public ByRefClass() { }
+        public bool ByRefNullableReferenceParam(PublicApiGeneratorTests.Examples.ReturnType rt1, ref PublicApiGeneratorTests.Examples.ReturnType? rt2, PublicApiGeneratorTests.Examples.ReturnType rt3, PublicApiGeneratorTests.Examples.ReturnType? rt4, out PublicApiGeneratorTests.Examples.ReturnType? rt5, PublicApiGeneratorTests.Examples.ReturnType rt6) { }
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_Annotate_Different_API()
+        {
+            AssertPublicApi<NullableApi>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class NullableApi
+    {
+        public PublicApiGeneratorTests.Examples.ReturnType NonNullField;
+        public PublicApiGeneratorTests.Examples.ReturnType? NullableField;
+        public NullableApi() { }
+        public System.Collections.Generic.Dictionary<string, System.Collections.Generic.Dictionary<string, System.Collections.Generic.Dictionary<int, int?>?>>? ComplicatedDictionary { get; set; }
+        public PublicApiGeneratorTests.Examples.ReturnType NonNullProperty { get; set; }
+        public PublicApiGeneratorTests.Examples.ReturnType? NullableProperty { get; set; }
+        public string? Convert(string source) { }
+        public override bool Equals(object? obj) { }
+        public override int GetHashCode() { }
+        public PublicApiGeneratorTests.Examples.ReturnType? NullableParamAndReturnMethod(string? nullableParam, string nonNullParam, int? nullableValueType) { }
+        public PublicApiGeneratorTests.Examples.ReturnType NullableParamMethod(string? nullableParam, string nonNullParam, int? nullableValueType) { }
+        public PublicApiGeneratorTests.Examples.Data<string> NullableStruct1(PublicApiGeneratorTests.Examples.Data<string> param) { }
+        public PublicApiGeneratorTests.Examples.Data<string>? NullableStruct2(PublicApiGeneratorTests.Examples.Data<string>? param) { }
+        public PublicApiGeneratorTests.Examples.Data<System.Collections.Generic.KeyValuePair<string, string?>> NullableStruct3(PublicApiGeneratorTests.Examples.Data<System.Collections.Generic.KeyValuePair<string, string?>> param) { }
+        public PublicApiGeneratorTests.Examples.Data<System.Collections.Generic.KeyValuePair<string, string?>?> NullableStruct4(PublicApiGeneratorTests.Examples.Data<System.Collections.Generic.KeyValuePair<string, string?>?> param) { }
+        public PublicApiGeneratorTests.Examples.Data<System.Collections.Generic.KeyValuePair<string, string?>?>? NullableStruct5(PublicApiGeneratorTests.Examples.Data<System.Collections.Generic.KeyValuePair<string, string?>?>? param) { }
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_Annotate_System_Nullable()
+        {
+            AssertPublicApi<SystemNullable>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class SystemNullable
+    {
+        public readonly int? Age;
+        public SystemNullable() { }
+        public System.DateTime? Birth { get; set; }
+        public float? Calc(double? first, decimal? second) { }
+        public System.Collections.Generic.List<System.Guid?> GetSecrets(System.Collections.Generic.Dictionary<int?, System.Collections.Generic.Dictionary<bool?, byte?>> data) { }
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_Annotate_Generics()
+        {
+            AssertPublicApi<Generics>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class Generics
+    {
+           public Generics() { }
+           public System.Collections.Generic.List<string?> GetSecretData0() { }
+           public System.Collections.Generic.Dictionary<int, System.Collections.Generic.List<int?>> GetSecretData1() { }
+           public System.Collections.Generic.Dictionary<int, System.Collections.Generic.List<int?>?> GetSecretData2() { }
+           public System.Collections.Generic.Dictionary<int, System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<string?, System.Collections.Generic.List<int>?>>> GetSecretData3(System.Collections.Generic.Dictionary<int?, System.Collections.Generic.List<System.Collections.Generic.KeyValuePair<string, System.Collections.Generic.List<int?>>>>? value) { }
+           public System.Collections.Generic.Dictionary<int?, string>? GetSecretData4(System.Collections.Generic.Dictionary<int?, string>? value) { }
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_Annotate_Structs()
+        {
+            AssertPublicApi<Structs>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class Structs
+    {
+           public System.Collections.Generic.KeyValuePair<string?, int?> field;
+           public Structs() { }
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_Annotate_Tuples()
+        {
+            AssertPublicApi<Tuples>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class Tuples
+    {
+           public Tuples() { }
+           public System.Tuple<string, string?, int, int?> Tuple1(System.Tuple<string, string?, int, int?>? tuple) { }
+           public System.ValueTuple<string, string?, int, int?> Tuple2(System.ValueTuple<string, string?, int, int?>? tuple) { }
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_Annotate_Constraints()
+        {
+            AssertPublicApi<Constraints>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class Constraints
+    {
+           public Constraints() { }
+           public void Print1<T>(T val)
+               where T : class { }
+           public void Print2<T>(T val)
+               where T : class? { }
+           public static void Print3<T>()
+                where T : System.IO.Stream { }
+           public static void Print4<T>()
+                where T : System.IDisposable { }
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_Annotate_Nullable_Constraints()
+        {
+            AssertPublicApi(typeof(Constraints2<,>),
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class Constraints2<X, Y>
+        where X : System.IComparable<X>
+        where Y : class?
+    {
+           public Constraints2() { }
+           public T Convert<T>(T data)
+               where T : System.IComparable<string?> { }
+           public static void Print1<T>()
+                where T : System.IO.Stream? { }
+           public static void Print2<T>()
+                where T : System.IDisposable? { }
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_Annotate_BaseType()
+        {
+            AssertPublicApi<NullableComparable>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class NullableComparable : System.Collections.Generic.List<string?>, System.IComparable<string?>
+    {
+           public NullableComparable() { }
+           public int CompareTo(string? other) { }
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_Annotate_OpenGeneric()
+        {
+            AssertPublicApi(typeof(StringNullableList<,>),
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class StringNullableList<T, U> : System.Collections.Generic.List<T?>, System.IComparable<U>
+        where T : struct
+        where U : class
+    {
+           public StringNullableList() { }
+           public int CompareTo(U other) { }
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_Annotate_NotNull_Constraint()
+        {
+            AssertPublicApi(typeof(IDoStuff1<,>),
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public interface IDoStuff1<TIn, TOut>
+         where TIn : notnull
+         where TOut : notnull
+    {
+           TOut DoStuff(TIn input);
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_Annotate_NotNull_And_Null_Constraint()
+        {
+            AssertPublicApi(typeof(IDoStuff2<,>),
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public interface IDoStuff2<TIn, TOut>
+         where TIn : class?
+         where TOut : notnull
+    {
+           TOut DoStuff(TIn input);
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_Annotate_Without_Explicit_Constraints()
+        {
+            AssertPublicApi(typeof(IDoStuff3<,>),
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public interface IDoStuff3<TIn, TOut>
+    {
+           TOut DoStuff(TIn input);
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_Annotate_NotNull_And_Null_Class_Constraint()
+        {
+            AssertPublicApi(typeof(IDoStuff4<,>),
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public interface IDoStuff4<TIn, TOut>
+         where TIn : class?
+         where TOut : class
+    {
+           TOut DoStuff(TIn input);
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_Annotate_Nullable_Class_And_Struct_Constraint()
+        {
+            AssertPublicApi(typeof(IDoStuff5<,>),
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public interface IDoStuff5<TIn, TOut>
+         where TIn : class?
+         where TOut : struct
+    {
+           TOut DoStuff(TIn input);
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_Annotate_Unmanaged_Constraint()
+        {
+            AssertPublicApi(typeof(IDoStuff6<,>),
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public interface IDoStuff6<TIn, TOut>
+         where TIn : notnull
+         where TOut : unmanaged
+    {
+           TOut DoStuff(TIn input);
+    }
+}");
+        }
+    }
+
+#nullable enable
+
+    // ReSharper disable ClassNeverInstantiated.Global
+    namespace Examples
+    {
+        public class ReturnType
+        {
+            public string? ReturnProperty { get; set; }
+        }
+
+        public static class VoidReturn
+        {
+            public static void ShouldBeEquivalentTo(this object? actual, object? expected) { }
+        }
+
+        public class ReturnArgs : EventArgs
+        {
+            public string? Target { get; set; }
+        }
+
+        public class NullableCtor
+        {
+            public NullableCtor(string? nullableLabel, string nope) { }
+        }
+
+        [Obsolete("Foo")]
+        public class ClassWithObsolete
+        {
+            [Obsolete("Bar")]
+            public ClassWithObsolete(string? nullableLabel) { }
+
+            [Obsolete("Bar")]
+            public ClassWithObsolete(string? nullableLabel, string? nullableLabel2) { }
+        }
+
+        public class GenericEvent
+        {
+            public event EventHandler<ReturnArgs?> ReturnEvent { add { } remove { } }
+        }
+
+        public class DelegateDeclaration
+        {
+            protected delegate string OnReturn(object sender, ReturnArgs? args);
+            protected delegate string? OnNullableReturn(object sender, ReturnArgs? args);
+        }
+
+        public class Structs
+        {
+            public KeyValuePair<string?, int?> field;
+        }
+
+        public struct Data<T>
+        {
+            public T Value { get; }
+        }
+
+        public class Generics
+        {
+            public List<string?> GetSecretData0() => null;
+            public Dictionary<int, List<int?>> GetSecretData1() => null;
+            public Dictionary<int, List<int?>?> GetSecretData2() => null;
+            public Dictionary<int, List<KeyValuePair<string?, List<int>?>>> GetSecretData3(Dictionary<int?, List<KeyValuePair<string, List<int?>>>>? value) { return null; }
+            public Dictionary<int?, string>? GetSecretData4(Dictionary<int?, string>? value) { return null; }
+        }
+
+        public class NullableArray
+        {
+            public ReturnType[]? NullableMethod1() { return null; }
+            public ReturnType[]?[]? NullableMethod2() { return null; }
+        }
+
+        public class NullableEnumerable
+        {
+            public IEnumerable<ReturnType?>? Enumerable() { return null; }
+        }
+
+        public class GenericMethod
+        {
+            public ReturnType? NullableGenericMethod<T1, T2, T3>(T1? t1, T2 t2, T3? t3) where T1 : class where T2 : class where T3 : class { return null; }
+        }
+
+        public class SkeetExamplesClass
+        {
+            public Dictionary<List<string?>, string[]?> SkeetExample = new Dictionary<List<string?>, string[]?>();
+            public Dictionary<List<string?>, string?[]> SkeetExample2 = new Dictionary<List<string?>, string?[]>();
+            public Dictionary<List<string?>, string?[]?> SkeetExample3 = new Dictionary<List<string?>, string?[]?>();
+        }
+
+        public class ByRefClass
+        {
+            public bool ByRefNullableReferenceParam(ReturnType rt1, ref ReturnType? rt2, ReturnType rt3, ReturnType? rt4, out ReturnType? rt5, ReturnType rt6) { rt5 = null; return false; }
+        }
+
+        public class NullableApi
+        {
+            public ReturnType NonNullField = new ReturnType();
+            public ReturnType? NullableField;
+            public ReturnType NonNullProperty { get; protected set; } = new ReturnType();
+            public ReturnType? NullableProperty { get; set; }
+            public ReturnType NullableParamMethod(string? nullableParam, string nonNullParam, int? nullableValueType) { return new ReturnType(); }
+            public ReturnType? NullableParamAndReturnMethod(string? nullableParam, string nonNullParam, int? nullableValueType) { return default; }
+            public Dictionary<string, Dictionary<string, Dictionary<int, int?>?>>? ComplicatedDictionary { get; set; }
+            public override bool Equals(object? obj) => base.Equals(obj);
+            public override int GetHashCode() => base.GetHashCode();
+            public string? Convert(string source) => source;
+            public Data<string> NullableStruct1(Data<string> param) => default;
+            public Data<string>? NullableStruct2(Data<string>? param) => default;
+            public Data<KeyValuePair<string, string?>> NullableStruct3(Data<KeyValuePair<string, string?>> param) => default;
+            public Data<KeyValuePair<string, string?>?> NullableStruct4(Data<KeyValuePair<string, string?>?> param) => default;
+            public Data<KeyValuePair<string, string?>?>? NullableStruct5(Data<KeyValuePair<string, string?>?>? param) => default;
+        }
+
+        public class SystemNullable
+        {
+            public readonly int? Age;
+            public DateTime? Birth { get; set; }
+
+            public float? Calc(double? first, decimal? second) { return null; }
+
+            public List<Guid?> GetSecrets(Dictionary<int?, Dictionary<bool?, byte?>> data) => null;
+        }
+
+        public class Tuples
+        {
+            public Tuple<string, string?, int, int?> Tuple1(Tuple<string, string?, int, int?>? tuple) => default;
+            public ValueTuple<string, string?, int, int?> Tuple2(ValueTuple<string, string?, int, int?>? tuple) => default;
+        }
+
+        public class Constraints
+        {
+            public void Print1<T>(T val) where T : class
+            {
+                val.ToString();
+            }
+
+            public void Print2<T>(T val) where T : class?
+            {
+                if (val != null)
+                    val.ToString();
+            }
+
+            public static void Print3<T>() where T : Stream { }
+            public static void Print4<T>() where T : IDisposable { }
+        }
+
+        public class Constraints2<X, Y> where X: IComparable<X> where Y : class?
+        {
+            public T Convert<T>(T data) where T : IComparable<string?> => default;
+            public static void Print1<T>() where T : Stream? { }
+            public static void Print2<T>() where T : IDisposable? { }
+        }
+
+        public class NullableComparable : List<string?>, IComparable<string?>
+        {
+            public int CompareTo(string? other)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public class StringNullableList<T,U> : List<T?>, IComparable<U> where T : struct where U : class
+        {
+            public int CompareTo(U other) => 0;
+        }
+
+        public interface IDoStuff1<TIn, TOut>
+            where TIn : notnull
+            where TOut : notnull
+        {
+            TOut DoStuff(TIn input);
+        }
+
+        public interface IDoStuff2<TIn, TOut>
+           where TIn : class?
+           where TOut : notnull
+        {
+            TOut DoStuff(TIn input);
+        }
+
+        public interface IDoStuff3<TIn, TOut>
+        {
+            TOut DoStuff(TIn input);
+        }
+
+        public interface IDoStuff4<TIn, TOut>
+          where TIn : class?
+          where TOut : class
+        {
+            TOut DoStuff(TIn input);
+        }
+
+        public interface IDoStuff5<TIn, TOut>
+         where TIn : class?
+         where TOut : struct
+        {
+            TOut DoStuff(TIn input);
+        }
+
+        public interface IDoStuff6<TIn, TOut>
+         where TIn : notnull
+         where TOut : unmanaged
+        {
+            TOut DoStuff(TIn input);
+        }
+    }
+    // ReSharper restore ClassNeverInstantiated.Global
+    // ReSharper restore UnusedMember.Global
+}

--- a/src/PublicApiGeneratorTests/PublicApiGeneratorTests.csproj
+++ b/src/PublicApiGeneratorTests/PublicApiGeneratorTests.csproj
@@ -2,8 +2,13 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
-    <NoWarn>$(NoWarn);CS0067</NoWarn>
-    <LangVersion>latest</LangVersion>
+    <NoWarn>$(NoWarn);CS0067;IDE0051;IDE0060;IDE1006</NoWarn>
+    <!--
+    CS0067  The event 'event' is never used
+    IDE0051 Private member 'SomeTest.Should_XXX' is unused.
+    IDE0060 Remove unused parameter 'name' if it is not part of a shipped public API
+    IDE1006 Naming rule violation: These words must begin with upper case characters
+    -->
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
C# 8 nullable reference type support
volatile without modreq
fixes #54 
fixes #108
fixes #107
readme note + .editorconfig
unmanaged and notnull constraints

This is final rebased and squashed version of #102 