### PR TITLE
Nullable Timespan

### DIFF
--- a/src/PublicApiGenerator/CSharpTypeKeyword.cs
+++ b/src/PublicApiGenerator/CSharpTypeKeyword.cs
@@ -36,6 +36,8 @@ namespace PublicApiGenerator
                     return "bool";
                 case "System.Void":
                     return "void";
+                case "System.TimeSpan":
+                    return "TimeSpan";                    
                 default:
                     return typeName;
             }

--- a/src/PublicApiGeneratorTests/Field_types.cs
+++ b/src/PublicApiGeneratorTests/Field_types.cs
@@ -91,6 +91,21 @@ namespace PublicApiGeneratorTests
     }
 }");
         }
+
+        [Fact]
+        public void Should_output_nullable_types()
+        {
+            AssertPublicApi<FieldWithNullable>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public class FieldWithNullable
+    {
+        public readonly int? NullableInt;
+        public readonly TimeSpan? NullableTimespan;
+        public FieldWithNullable() { }
+    }
+}");
+        }
     }
 
     // ReSharper disable ClassNeverInstantiated.Global
@@ -126,6 +141,12 @@ namespace PublicApiGeneratorTests
         {
             public readonly Func<string, string, string, IEnumerable<string>, string> FuncField = (a, b, c, d) => null;
             public readonly Func<string, string, string, string> FuncField2;
+        }
+
+        public class FieldWithNullable
+        {
+            public readonly TimeSpan? NullableTimespan;
+            public readonly int? NullableInt;
         }
     }
     // ReSharper restore UnusedMember.Global

--- a/src/PublicApiGeneratorTests/Method_extensions.cs
+++ b/src/PublicApiGeneratorTests/Method_extensions.cs
@@ -1,4 +1,5 @@
 using PublicApiGeneratorTests.Examples;
+using System;
 using System.Collections.Generic;
 using Xunit;
 
@@ -37,6 +38,21 @@ namespace PublicApiGeneratorTests
     }
 }");
         }
+
+        [Fact]
+        public void Should_output_extension_methods_with_nullable()
+        {
+            AssertPublicApi(typeof(ExtensionMethodWithNullable),
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public static class ExtensionMethodWithNullable
+    {
+            public static int? Int(this object @object, int? value = default) { }
+            public static long? Long(this object @object, long? value = default) { }
+            public static TimeSpan? Time(this object @object, TimeSpan? timeSpan = default) { }
+    }
+}");
+        }
     }
 
     // ReSharper disable UnusedMember.Global
@@ -61,6 +77,15 @@ namespace PublicApiGeneratorTests
             public static Configurator<T> Add<T, U>(this Configurator<T> configurator) where U : class, IComparer<T>, IEnumerable<U> => configurator;
 
             public static void Add<T, U>(this string s) where U : class, IComparer<T>, IEnumerable<U> { }
+        }
+
+        public static class ExtensionMethodWithNullable
+        {
+            public static TimeSpan? Time(this object @object, TimeSpan? timeSpan = null) => null;
+
+            public static int? Int(this object @object, int? @value = null) => null;
+
+            public static long? Long(this object @object, long? @value = null) => null;
         }
     }
     // ReSharper restore ClassNeverInstantiated.Global


### PR DESCRIPTION
@sungam3r found a small regression while testing with NServiceBus API

```
Expected: ▒▒▒    public readonly TimeSpan? NullableTimespan;\r\n        publ▒▒▒
Actual:   ▒▒▒    public readonly System.TimeSpan? NullableTimespan;\r\n     ▒▒▒
```
