### PR TITLE
Enable debugger source-stepping

### DIFF
--- a/src/PublicApiGenerator/PublicApiGenerator.csproj
+++ b/src/PublicApiGenerator/PublicApiGenerator.csproj
@@ -6,6 +6,14 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\PublicApiGenerator.snk</AssemblyOriginatorKeyFile>
+
+    <!-- Enable debugger source-stepping by embedding source files in the PDB. -->
+    <EmbedAllSources>true</EmbedAllSources>
+
+    <!-- The PDBs go in a .snupkg file to be uploaded to the nuget.org symbol server. -->
+    <!-- https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg -->
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
A .snupkg file will now appear in the build artifacts. When you do `nuget push Foo.nupkg`, it automatically pushes `Foo.snupkg` as long as it is still in the same folder. More details at https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg#publishing-a-symbol-package.

Make sure that when you push, the NuGet source URL that you're pushing to is a v3 URL (`https://api.nuget.org/v3/index.json`), not a v2 URL, or this will not happen.

To step into ApiApprover code from a consuming project like Shouldly, all that is required is to temporarily turn off [Debug > Options > Enable Just My Code](https://docs.microsoft.com/en-us/visualstudio/debugger/just-my-code) and make sure that the VS2019 default NuGet Symbol Server option is still enabled:

![image](https://user-images.githubusercontent.com/8040367/68350961-0f69a200-00d0-11ea-9efe-2a37e32b431f.png)
