### PR TITLE
Propagate DefaultMemberAttribute to IndexerNameAttribute

### DIFF
--- a/src/PublicApiGenerator/ApiGenerator.cs
+++ b/src/PublicApiGenerator/ApiGenerator.cs
@@ -685,16 +685,18 @@ namespace PublicApiGenerator
             };
 
             // DefaultMemberAttribute on type gets propagated to IndexerNameAttribute
-            var defaultMemberAttribute = typeDeclarationInfo.CustomAttributes.SingleOrDefault(x =>
-                x.AttributeType.FullName == "System.Reflection.DefaultMemberAttribute");
-            var defaultMemberAttributeArgument = defaultMemberAttribute?.ConstructorArguments.SingleOrDefault();
-            var value = defaultMemberAttributeArgument?.Value as string;
-            if (!string.IsNullOrEmpty(value) && propertyName != "Item")
+            var defaultMemberAttributeValue = typeDeclarationInfo.CustomAttributes.SingleOrDefault(x =>
+                    x.AttributeType.FullName == "System.Reflection.DefaultMemberAttribute")
+                ?.ConstructorArguments.Select(x => x.Value).OfType<string>().SingleOrDefault();
+            if (!string.IsNullOrEmpty(defaultMemberAttributeValue) && propertyName != "Item")
             {
                 property.Name = "Item";
-                var codeAttributeDeclaration = new CodeAttributeDeclaration(AttributeNameBuilder.Get("System.Runtime.CompilerServices.IndexerNameAttribute"));
-                codeAttributeDeclaration.Arguments.Add(new CodeAttributeArgument(new CodePrimitiveExpression(value)));
-                property.CustomAttributes.Add(codeAttributeDeclaration);
+                property.CustomAttributes.Add(
+                    new CodeAttributeDeclaration(
+                        AttributeNameBuilder.Get("System.Runtime.CompilerServices.IndexerNameAttribute"))
+                    {
+                        Arguments = {new CodeAttributeArgument(new CodePrimitiveExpression(defaultMemberAttributeValue))}
+                    });
             }
 
             // Here's a nice hack, because hey, guess what, the CodeDOM doesn't support

--- a/src/PublicApiGenerator/ApiGenerator.cs
+++ b/src/PublicApiGenerator/ApiGenerator.cs
@@ -180,6 +180,7 @@ namespace PublicApiGenerator
         }
 
         static void AddMemberToTypeDeclaration(CodeTypeDeclaration typeDeclaration,
+            IMemberDefinition typeDeclarationInfo,
             IMemberDefinition memberInfo,
             AttributeFilter attributeFilter)
         {
@@ -194,7 +195,7 @@ namespace PublicApiGenerator
                 }
                 else if (memberInfo is PropertyDefinition propertyDefinition)
                 {
-                    AddPropertyToTypeDeclaration(typeDeclaration, propertyDefinition, attributeFilter);
+                    AddPropertyToTypeDeclaration(typeDeclaration, typeDeclarationInfo, propertyDefinition, attributeFilter);
                 }
                 else if (memberInfo is EventDefinition eventDefinition)
                 {
@@ -293,14 +294,14 @@ namespace PublicApiGenerator
                 declaration.BaseTypes.Add(@interface.InterfaceType.CreateCodeTypeReference(@interface));
 
             foreach (var memberInfo in publicType.GetMembers().Where(memberDefinition => ShouldIncludeMember(memberDefinition, whitelistedNamespacePrefixes)).OrderBy(m => m.Name, StringComparer.Ordinal))
-                AddMemberToTypeDeclaration(declaration, memberInfo, attributeFilter);
+                AddMemberToTypeDeclaration(declaration, publicType, memberInfo, attributeFilter);
 
             // Fields should be in defined order for an enum
             var fields = !publicType.IsEnum
                 ? publicType.Fields.OrderBy(f => f.Name, StringComparer.Ordinal)
                 : (IEnumerable<FieldDefinition>)publicType.Fields;
             foreach (var field in fields)
-                AddMemberToTypeDeclaration(declaration, field, attributeFilter);
+                AddMemberToTypeDeclaration(declaration, publicType, field, attributeFilter);
 
             foreach (var nestedType in publicType.NestedTypes.Where(ShouldIncludeType).OrderBy(t => t.FullName, StringComparer.Ordinal))
             {
@@ -445,10 +446,7 @@ namespace PublicApiGenerator
         static CodeAttributeDeclaration GenerateCodeAttributeDeclaration(Func<CodeTypeReference, CodeTypeReference> codeTypeModifier, CustomAttribute customAttribute)
         {
             var attribute = new CodeAttributeDeclaration(codeTypeModifier(customAttribute.AttributeType.CreateCodeTypeReference(mode: NullableMode.Disable)));
-            if (attribute.Name != "System.ParamArrayAttribute")
-            {
-                attribute.Name = $"{attribute.Name}{CodeNormalizer.AttributeMarker}";
-            }
+            attribute.Name = AttributeNameBuilder.Get(attribute.Name);
             foreach (var arg in customAttribute.ConstructorArguments)
             {
                 attribute.Arguments.Add(new CodeAttributeArgument(CreateInitialiserExpression(arg)));
@@ -658,7 +656,7 @@ namespace PublicApiGenerator
             return parameter.ParameterType.IsValueType ? "default" : "null";
         }
 
-        static void AddPropertyToTypeDeclaration(CodeTypeDeclaration typeDeclaration, PropertyDefinition member, AttributeFilter attributeFilter)
+        static void AddPropertyToTypeDeclaration(CodeTypeDeclaration typeDeclaration, IMemberDefinition typeDeclarationInfo, PropertyDefinition member, AttributeFilter attributeFilter)
         {
             var getterAttributes = member.GetMethod?.GetMethodAttributes() ?? 0;
             var setterAttributes = member.SetMethod?.GetMethodAttributes() ?? 0;
@@ -675,15 +673,29 @@ namespace PublicApiGenerator
                 ? new CodeTypeReference(member.PropertyType.Name)
                 : member.PropertyType.CreateCodeTypeReference(member);
 
+            var propertyName = member.Name;
             var property = new CodeMemberProperty
             {
-                Name = member.Name,
+                Name = propertyName,
                 Type = propertyType,
                 Attributes = propertyAttributes,
                 CustomAttributes = CreateCustomAttributes(member, attributeFilter),
                 HasGet = hasGet,
                 HasSet = hasSet
             };
+
+            // DefaultMemberAttribute on type gets propagated to IndexerNameAttribute
+            var defaultMemberAttribute = typeDeclarationInfo.CustomAttributes.SingleOrDefault(x =>
+                x.AttributeType.FullName == "System.Reflection.DefaultMemberAttribute");
+            var defaultMemberAttributeArgument = defaultMemberAttribute?.ConstructorArguments.SingleOrDefault();
+            var value = defaultMemberAttributeArgument?.Value as string;
+            if (!string.IsNullOrEmpty(value) && propertyName != "Item")
+            {
+                property.Name = "Item";
+                var codeAttributeDeclaration = new CodeAttributeDeclaration(AttributeNameBuilder.Get("System.Runtime.CompilerServices.IndexerNameAttribute"));
+                codeAttributeDeclaration.Arguments.Add(new CodeAttributeArgument(new CodePrimitiveExpression(value)));
+                property.CustomAttributes.Add(codeAttributeDeclaration);
+            }
 
             // Here's a nice hack, because hey, guess what, the CodeDOM doesn't support
             // attributes on getters or setters

--- a/src/PublicApiGenerator/AttributeNameBuilder.cs
+++ b/src/PublicApiGenerator/AttributeNameBuilder.cs
@@ -4,7 +4,8 @@ namespace PublicApiGenerator
     {
         public static string Get(string name)
         {
-            return name != "System.ParamArrayAttribute" ? $"{name}{CodeNormalizer.AttributeMarker}" : name;
+            // ParamArrayAttribute cannot be augment with the attribute marker, it would trip up CodeDom
+            return name == "System.ParamArrayAttribute" ? name : $"{name}{CodeNormalizer.AttributeMarker}";
         }
     }
 }

--- a/src/PublicApiGenerator/AttributeNameBuilder.cs
+++ b/src/PublicApiGenerator/AttributeNameBuilder.cs
@@ -1,0 +1,10 @@
+namespace PublicApiGenerator
+{
+    public static class AttributeNameBuilder
+    {
+        public static string Get(string name)
+        {
+            return name != "System.ParamArrayAttribute" ? $"{name}{CodeNormalizer.AttributeMarker}" : name;
+        }
+    }
+}

--- a/src/PublicApiGeneratorTests/Indexer_properties.cs
+++ b/src/PublicApiGeneratorTests/Indexer_properties.cs
@@ -1,0 +1,59 @@
+using System.Runtime.CompilerServices;
+using PublicApiGeneratorTests.Examples;
+using Xunit;
+
+namespace PublicApiGeneratorTests
+{
+    public class Indexer_properties : ApiGeneratorTestsBase
+    {
+        [Fact]
+        public void Should_output_indexer()
+        {
+            AssertPublicApi<ClassWithIndexer>(
+                @"namespace PublicApiGeneratorTests.Examples
+{
+    public class ClassWithIndexer
+    {
+        public ClassWithIndexer() { }
+        public int this[int x] { get; }
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_output_named_indexer()
+        {
+            AssertPublicApi<ClassWithNamedIndexer>(
+                @"namespace PublicApiGeneratorTests.Examples
+{
+    public class ClassWithNamedIndexer
+    {
+        public ClassWithNamedIndexer() { }
+        [System.Runtime.CompilerServices.IndexerName(""Bar"")]
+        public int this[int x] { get; }
+    }
+}");
+        }
+    }
+
+
+    // ReSharper disable ClassNeverInstantiated.Global
+    // ReSharper disable UnusedMember.Global
+    // ReSharper disable ValueParameterNotUsed
+    namespace Examples
+    {
+        public class ClassWithIndexer
+        {
+            public int this[int x] => x;
+        }
+
+        public class ClassWithNamedIndexer
+        {
+            [IndexerName("Bar")]
+            public int this[int x] => x;
+        }
+    }
+    // ReSharper restore ValueParameterNotUsed
+    // ReSharper restore UnusedMember.Global
+    // ReSharper restore ClassNeverInstantiated.Global
+}

--- a/src/PublicApiGeneratorTests/Indexer_properties.cs
+++ b/src/PublicApiGeneratorTests/Indexer_properties.cs
@@ -34,6 +34,21 @@ namespace PublicApiGeneratorTests
     }
 }");
         }
+
+        [Fact]
+        public void Should_output_named_indexer_with_getset()
+        {
+            AssertPublicApi<ClassWithNamedIndexerGetSet>(
+                @"namespace PublicApiGeneratorTests.Examples
+{
+    public class ClassWithNamedIndexerGetSet
+    {
+        public ClassWithNamedIndexerGetSet() { }
+        [System.Runtime.CompilerServices.IndexerName(""Bar"")]
+        public int this[int x] { get; set; }
+    }
+}");
+        }
     }
 
 
@@ -51,6 +66,18 @@ namespace PublicApiGeneratorTests
         {
             [IndexerName("Bar")]
             public int this[int x] => x;
+        }
+
+        public class ClassWithNamedIndexerGetSet
+        {
+            private int y;
+
+            [IndexerName("Bar")]
+            public int this[int x]
+            {
+                get => y;
+                set => y = value;
+            }
         }
     }
     // ReSharper restore ValueParameterNotUsed


### PR DESCRIPTION
Closes #106

I think soon I will need to cleanup the dependencies between the names and the code normalizer a bit but for now the name uses the markers defined on the normalizer