### PR TITLE
Fix virtual event

### DIFF
--- a/src/PublicApiGenerator/EventNameBuilder.cs
+++ b/src/PublicApiGenerator/EventNameBuilder.cs
@@ -30,7 +30,7 @@ namespace PublicApiGenerator
             {
                 var typeDef = baseType as TypeDefinition;
                 isNew = typeDef?.Methods.Any(e => e.Name.Equals(eventDefinition.AddMethod.Name, StringComparison.Ordinal));
-                if (isNew.HasValue && isNew.Value)
+                if (isNew == true)
                 {
                     break;
                 }
@@ -48,6 +48,7 @@ namespace PublicApiGenerator
                     (MemberAttributes.Abstract, null, _, _) => Format(CodeNormalizer.EventModifierMarkerTemplate, "abstract") + name,
                     (MemberAttributes.Abstract, true, _, _) => Format(CodeNormalizer.EventModifierMarkerTemplate, "new abstract") + name,
                     (MemberAttributes.Const, _, _, _) => Format(CodeNormalizer.EventModifierMarkerTemplate, "abstract override") + name,
+                    (MemberAttributes.Final, null, true, false) => name,
                     (_, null, true, false) => Format(CodeNormalizer.EventModifierMarkerTemplate, "virtual") + name,
                     (_, true, true, false) => Format(CodeNormalizer.EventModifierMarkerTemplate, "new virtual") + name,
                     _ => name

--- a/src/PublicApiGeneratorTests/Class_constructors.cs
+++ b/src/PublicApiGeneratorTests/Class_constructors.cs
@@ -47,6 +47,16 @@ namespace PublicApiGeneratorTests
         }
 
         [Fact]
+        public void Should_not_output_private_constructor_from_abstract_class()
+        {
+            AssertPublicApi<AbstractClassWithPrivateCtor>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public abstract class AbstractClassWithPrivateCtor { }
+}");
+        }
+
+        [Fact]
         public void Should_not_output_internal_constructor()
         {
             AssertPublicApi<ClassWithInternalConstructor>(
@@ -275,6 +285,11 @@ namespace PublicApiGeneratorTests
         {
             public AbstractClassWithCtors(int i) { }
             protected AbstractClassWithCtors(string j) { }
+        }
+
+        public abstract class AbstractClassWithPrivateCtor
+        {
+            private AbstractClassWithPrivateCtor(int i) { }
         }
     }
     // ReSharper restore UnusedMember.Global

--- a/src/PublicApiGeneratorTests/Class_constructors.cs
+++ b/src/PublicApiGeneratorTests/Class_constructors.cs
@@ -20,6 +20,33 @@ namespace PublicApiGeneratorTests
         }
 
         [Fact]
+        public void Should_output_protected_default_constructor_in_abstract_class()
+        {
+            AssertPublicApi<AbstractClass>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public abstract class AbstractClass
+    {
+        protected AbstractClass() { }
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_not_output_protected_default_constructor_in_abstract_class_with_other_constructors()
+        {
+            AssertPublicApi<AbstractClassWithCtors>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public abstract class AbstractClassWithCtors
+    {
+        public AbstractClassWithCtors(int i) { }
+        protected AbstractClassWithCtors(string j) { }
+    }
+}");
+        }
+
+        [Fact]
         public void Should_not_output_internal_constructor()
         {
             AssertPublicApi<ClassWithInternalConstructor>(
@@ -242,6 +269,12 @@ namespace PublicApiGeneratorTests
             static StaticClassWithStaticConstructor()
             {
             }
+        }
+
+        public abstract class AbstractClassWithCtors
+        {
+            public AbstractClassWithCtors(int i) { }
+            protected AbstractClassWithCtors(string j) { }
         }
     }
     // ReSharper restore UnusedMember.Global

--- a/src/PublicApiGeneratorTests/Event_visibility.cs
+++ b/src/PublicApiGeneratorTests/Event_visibility.cs
@@ -1,4 +1,4 @@
-﻿using PublicApiGeneratorTests.Examples;
+using PublicApiGeneratorTests.Examples;
 using System;
 using Xunit;
 
@@ -15,6 +15,20 @@ namespace PublicApiGeneratorTests
     public class ClassWithPublicEvent
     {
         public ClassWithPublicEvent() { }
+        public event System.EventHandler Event;
+    }
+}");
+        }
+
+        [Fact]
+        public void Should_output_public_event_from_abstract_class()
+        {
+            AssertPublicApi<AbstractClassWithEvent>(
+@"namespace PublicApiGeneratorTests.Examples
+{
+    public abstract class AbstractClassWithEvent : PublicApiGeneratorTests.Examples.InterfaceWithEvent
+    {
+        protected AbstractClassWithEvent() { }
         public event System.EventHandler Event;
     }
 }");
@@ -122,6 +136,16 @@ namespace PublicApiGeneratorTests
         public class ClassWithPrivateProtectedEvent
         {
             private protected event EventHandler Event;
+        }
+
+        public abstract class AbstractClassWithEvent : InterfaceWithEvent
+        {
+            public event EventHandler Event;
+        }
+
+        public interface InterfaceWithEvent
+        {
+            event EventHandler Event;
         }
     }
     // ReSharper restore UnusedMember.Local


### PR DESCRIPTION
Before:
```c#
   public abstract class AbstractClassWithEvent : PublicApiGeneratorTests.Examples.InterfaceWithEvent
    {
        protected AbstractClassWithEvent() { }
        public virtual event System.EventHandler Event;
    }
```
After:
```c#
   public abstract class AbstractClassWithEvent : PublicApiGeneratorTests.Examples.InterfaceWithEvent
    {
        protected AbstractClassWithEvent() { }
        public event System.EventHandler Event;
    }
```

In a separate commits I added several tests. I would like to ask whether the default constructor (protected) is correctly displayed by the abstract class? It seems to me that is right, but I doubt it.