### PR TITLE
sort members on parameter count

### DIFF
--- a/src/PublicApiGenerator/CodeTypeDeclarationExtensions.cs
+++ b/src/PublicApiGenerator/CodeTypeDeclarationExtensions.cs
@@ -49,6 +49,9 @@ namespace PublicApiGenerator
                             ? method.TypeParameters.Count
                             : 0)
                 .ThenBy(m => m is CodeMemberMethod method
+                            ? method.Parameters.Count
+                            : 0)
+                .ThenBy(m => m is CodeMemberMethod method
                             ? method.Parameters.OfType<CodeParameterDeclarationExpression>().ToList()
                             : emptyParamList,
                         new ParamListComparer());
@@ -68,11 +71,6 @@ namespace PublicApiGenerator
                 var paramIndex = 0;
                 for (; paramIndex < x.Count; ++paramIndex)
                 {
-                    if (paramIndex == y.Count)
-                    {
-                        return 1;
-                    }
-
                     var paramX = x[paramIndex];
                     var paramY = y[paramIndex];
 

--- a/src/PublicApiGeneratorTests/Method_order.cs
+++ b/src/PublicApiGeneratorTests/Method_order.cs
@@ -17,7 +17,9 @@ namespace PublicApiGeneratorTests
         public void Method_AA() { }
         public void Method_AA<T>() { }
         public void Method_AA<T, U>() { }
-        public void Method_BB() { }
+        public void Method_BB(int foo) { }
+        public void Method_BB(string bar) { }
+        public void Method_BB(int foo, string bar) { }
         public void Method_I() { }
         public void Method_I(string arg) { }
         public void Method_i() { }
@@ -37,7 +39,15 @@ namespace PublicApiGeneratorTests
             {
             }
 
-            public void Method_BB()
+            public void Method_BB(int foo, string bar)
+            {
+            }
+
+            public void Method_BB(string bar)
+            {
+            }
+
+            public void Method_BB(int foo)
             {
             }
 


### PR DESCRIPTION
This tweaks the output to slightly more closely match what Intellisense does: simpler members (with less params) first and more complex members (with more params) later.